### PR TITLE
fix: expose plugin upload setting

### DIFF
--- a/chart/templates/mattermost-config.yaml
+++ b/chart/templates/mattermost-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mattermost-config
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  MM_PLUGINSETTINGS_ENABLEUPLOADS: "{{ .Values.config.enablePluginUploads | toString }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -29,3 +29,7 @@ sso:
 
 # The subdomain for the mattermost server, will be prefixed to your domain (ex: mattermost.example.com)
 subdomain: "chat"
+
+# Additional configuration for Mattermost
+config:
+  enablePluginUploads: false

--- a/values/values.yaml
+++ b/values/values.yaml
@@ -86,6 +86,12 @@ mattermostApp:
         secretKeyRef:
           key: MM_FILESETTINGS_AMAZONS3REGION
           name: "mattermost-object-store"
+    # Additional Mattermost Config
+    - name: MM_PLUGINSETTINGS_ENABLEUPLOADS
+      valueFrom:
+        secretKeyRef:
+          key: MM_PLUGINSETTINGS_ENABLEUPLOADS
+          name: "mattermost-config"
   securityContext:
     runAsUser: 2000
     runAsGroup: 2000


### PR DESCRIPTION
Partially solves https://github.com/defenseunicorns/uds-package-mattermost/issues/7

This is currently necessary to expose individual config options until the upstream chart supports an `envFrom` option which would let us pull all keys from a secret.