### PR TITLE
chore: fix renovate config to only allow semver on mattermost image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,14 @@
       "groupName": "Mattermost Package Dependencies",
       "labels": ["package-deps"],
       "commitMessageTopic": "package-deps",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["mattermost/mattermost-enterprise-edition"],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+$/"
+    },
+    {
+      "groupName": "Mattermost Package Dependencies",
+      "labels": ["package-deps"],
+      "commitMessageTopic": "package-deps",
       "matchPackageNames": ["https://repo1.dso.mil/big-bang/product/packages/mattermost.git"],
       "allowedVersions": "/.+-bb.+/"
     }


### PR DESCRIPTION
## Description
fix renovate config to only allow semver on mattermost image

## Related Issue

Fixes #
[50](https://github.com/defenseunicorns/uds-package-mattermost/issues/50)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-mattermost/blob/main/CONTRIBUTING.md#developer-workflow) followed
