### PR TITLE
feat: Extra env variable and MM_SQLSETTINGS_DATASOURCE env set

### DIFF
--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -92,6 +92,7 @@ mattermostApp:
         secretKeyRef:
           key: MM_PLUGINSETTINGS_ENABLEUPLOADS
           name: "mattermost-config"
+    ###ZARF_VAR_EXTRA_ENV###
   securityContext:
     runAsUser: 2000
     runAsGroup: 2000

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -92,7 +92,12 @@ mattermostApp:
         secretKeyRef:
           key: MM_PLUGINSETTINGS_ENABLEUPLOADS
           name: "mattermost-config"
-    ###ZARF_VAR_EXTRA_ENV###
+    - name: MM_SQLSETTINGS_DATASOURCE
+      valueFrom:
+        secretKeyRef:
+          key: db_connection_string
+          name: "mattermost-postgres"
+    ###ZARF_VAR_MM_EXTRA_ENV###
   securityContext:
     runAsUser: 2000
     runAsGroup: 2000

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -97,7 +97,7 @@ mattermostApp:
         secretKeyRef:
           key: db_connection_string
           name: "mattermost-postgres"
-    ###ZARF_VAR_MM_EXTRA_ENV###
+    ###ZARF_VAR_EXTRA_ENV###
   securityContext:
     runAsUser: 2000
     runAsGroup: 2000

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -19,6 +19,10 @@ variables:
     description: "Secret Key for S3 compatible storage"
   - name: DB_PASSWORD
     description: "Database Password for Mattermost"
+  - name: EXTRA_ENV
+    description: "Sets an extra env variable for the mattermost chart"
+    default: ""
+    autoIndent: true
 
 components:
   - name: mattermost


### PR DESCRIPTION
## Description

- Adds a field to add extra environment settings to the Mattermost chart.

- Sets `MM_SQLSETTINGS_DATASOURCE` so that when backing up a Mattermost it uses the set connection string, instead of the default behavior. For more info, see this [issue](https://github.com/mattermost/mattermost/issues/25696) on the mattermost github.

## Related Issue

Fixes #53 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-mattermost/blob/main/CONTRIBUTING.md#developer-workflow) followed
