### PR TITLE
chore: update extraEnv to envFrom

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 This package is designed for use as part of a [UDS Software Factory](https://github.com/defenseunicorns/uds-software-factory) bundle deployed on [UDS Core](https://github.com/defenseunicorns/uds-core).
 
+> [!TIP]
+> To add additional environment variables to Mattermost you can do so by overriding the `extraEnv` key in the `uds-mattermost-config` chart.
+> ```yaml
+> overrides:
+>   mattermost:
+>     uds-mattermost-config:
+>       values:
+>         - path: "extraEnv"
+>           value:
+>             MY_ENV_VAR: "an env var value"
+> ```
+
 ## Prerequisites
 
 Mattermost requires two dependencies, postgres and s3 compatible object storage. Wiring Mattermost to your dependencies is done primarily via helm values, which will require the use of a bundle created with uds-cli.

--- a/chart/templates/mattermost-extra-env.yaml
+++ b/chart/templates/mattermost-extra-env.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mattermost-extra-env
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+{{- with .Values.extraEnv }}
+{{- toYaml . | nindent 2 }}
+{{- end }}

--- a/chart/templates/mattermost-object-store.yaml
+++ b/chart/templates/mattermost-object-store.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
+  MM_FILESETTINGS_DRIVERNAME: amazons3
   MM_FILESETTINGS_AMAZONS3SSL: "{{ .Values.objectStorage.secure | toString }}"
   MM_FILESETTINGS_AMAZONS3ACCESSKEYID: "{{ .Values.objectStorage.accessKey }}"
   MM_FILESETTINGS_AMAZONS3SECRETACCESSKEY: "{{ .Values.objectStorage.secretKey }}"

--- a/chart/templates/mattermost-postgres.yaml
+++ b/chart/templates/mattermost-postgres.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  db_connection_string: "postgres://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@{{ .Values.postgres.host }}:{{ .Values.postgres.port }}/{{ .Values.postgres.dbName }}{{ .Values.postgres.connectionOptions }}"
+  MM_SQLSETTINGS_DATASOURCE: "postgres://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@{{ .Values.postgres.host }}:{{ .Values.postgres.port }}/{{ .Values.postgres.dbName }}{{ .Values.postgres.connectionOptions }}"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -33,3 +33,6 @@ subdomain: "chat"
 # Additional configuration for Mattermost
 config:
   enablePluginUploads: false
+
+# Additional environment variables for Mattermost
+extraEnv: {}

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -6,97 +6,22 @@ mattermostApp:
   # Default replicacount due to HA requiring a license
   replicaCount: 1
   # Mattermost does not provide helm values to configure all the options so it is done via ENV
-  extraEnv:
+  envFrom:
     # SSO Settings
-    - name: MM_GITLABSETTINGS_ENABLE
-      valueFrom:
-        secretKeyRef:
-          key: MM_GITLABSETTINGS_ENABLE
-          name: "mattermost-sso"
-    - name: MM_GITLABSETTINGS_ID
-      valueFrom:
-        secretKeyRef:
-          key: MM_GITLABSETTINGS_ID
-          name: "mattermost-sso"
-    - name: MM_GITLABSETTINGS_SECRET
-      valueFrom:
-        secretKeyRef:
-          key: MM_GITLABSETTINGS_SECRET
-          name: "mattermost-sso"
-    - name: MM_GITLABSETTINGS_AUTHENDPOINT
-      valueFrom:
-        secretKeyRef:
-          key: MM_GITLABSETTINGS_AUTHENDPOINT
-          name: "mattermost-sso"
-    - name: MM_GITLABSETTINGS_TOKENENDPOINT
-      valueFrom:
-        secretKeyRef:
-          key: MM_GITLABSETTINGS_TOKENENDPOINT
-          name: "mattermost-sso"
-    - name: MM_GITLABSETTINGS_USERAPIENDPOINT
-      valueFrom:
-        secretKeyRef:
-          key: MM_GITLABSETTINGS_USERAPIENDPOINT
-          name: "mattermost-sso"
-    - name: MM_EMAILSETTINGS_ENABLESIGNUPWITHEMAIL
-      valueFrom:
-        secretKeyRef:
-          key: MM_EMAILSETTINGS_ENABLESIGNUPWITHEMAIL
-          name: "mattermost-sso"
-    - name: MM_EMAILSETTINGS_ENABLESIGNINWITHEMAIL
-      valueFrom:
-        secretKeyRef:
-          key: MM_EMAILSETTINGS_ENABLESIGNINWITHEMAIL
-          name: "mattermost-sso"
-    - name: MM_EMAILSETTINGS_ENABLESIGNINWITHUSERNAME
-      valueFrom:
-        secretKeyRef:
-          key: MM_EMAILSETTINGS_ENABLESIGNINWITHUSERNAME
-          name: "mattermost-sso"
+    - secretRef:
+        name: mattermost-sso
     # Object Storage Connection
-    - name: MM_FILESETTINGS_DRIVERNAME
-      value: "amazons3"
-    - name: MM_FILESETTINGS_AMAZONS3SSL
-      valueFrom:
-        secretKeyRef:
-          key: MM_FILESETTINGS_AMAZONS3SSL
-          name: "mattermost-object-store"
-    - name: MM_FILESETTINGS_AMAZONS3ACCESSKEYID
-      valueFrom:
-        secretKeyRef:
-          key: MM_FILESETTINGS_AMAZONS3ACCESSKEYID
-          name: "mattermost-object-store"
-    - name: MM_FILESETTINGS_AMAZONS3SECRETACCESSKEY
-      valueFrom:
-        secretKeyRef:
-          key: MM_FILESETTINGS_AMAZONS3SECRETACCESSKEY
-          name: "mattermost-object-store"
-    - name: MM_FILESETTINGS_AMAZONS3BUCKET
-      valueFrom:
-        secretKeyRef:
-          key: MM_FILESETTINGS_AMAZONS3BUCKET
-          name: "mattermost-object-store"
-    - name: MM_FILESETTINGS_AMAZONS3ENDPOINT
-      valueFrom:
-        secretKeyRef:
-          key: MM_FILESETTINGS_AMAZONS3ENDPOINT
-          name: "mattermost-object-store"
-    - name: MM_FILESETTINGS_AMAZONS3REGION
-      valueFrom:
-        secretKeyRef:
-          key: MM_FILESETTINGS_AMAZONS3REGION
-          name: "mattermost-object-store"
-    # Additional Mattermost Config
-    - name: MM_PLUGINSETTINGS_ENABLEUPLOADS
-      valueFrom:
-        secretKeyRef:
-          key: MM_PLUGINSETTINGS_ENABLEUPLOADS
-          name: "mattermost-config"
-    - name: MM_SQLSETTINGS_DATASOURCE
-      valueFrom:
-        secretKeyRef:
-          key: db_connection_string
-          name: "mattermost-postgres"
+    - secretRef:
+        name: mattermost-object-store
+    # Database Configuration
+    - secretRef:
+        name: mattermost-postgres
+    # General Configuration
+    - secretRef:
+        name: mattermost-config
+    # Extra Configuration
+    - secretRef:
+        name: mattermost-extra-env
   securityContext:
     runAsUser: 2000
     runAsGroup: 2000
@@ -116,7 +41,7 @@ global:
       useInternal: false
       existingDatabaseSecret:
         name: mattermost-postgres
-        key: db_connection_string
+        key: MM_SQLSETTINGS_DATASOURCE
     # The job server is only necessary on multi-node/enterprise clusters
     # https://docs.mattermost.com/scale/high-availability-cluster.html#job-server
     # It also will error due to its init container being blocked by Istio mTLS


### PR DESCRIPTION
## Description

This updates Mattermost to use envFrom instead of extraEnv for greater simplicity and more flexibility.

## Related Issue

Fixes #57

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-mattermost/blob/main/CONTRIBUTING.md#developer-workflow) followed
