### PR TITLE
fix: replaced hardcoded redirectUri

### DIFF
--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -9,7 +9,7 @@ spec:
     - name: Mattermost Login
       clientId: uds-swf-mattermost
       redirectUris:
-        - "https://chat.uds.dev/*"
+        - "https://chat.{{ .Values.domain }}/*"
       defaultClientScopes:
         - "openid"
         - "mapper-oidc-username-username"


### PR DESCRIPTION
## Description

RedirectUri domain was hardcoded to `uds.dev`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-mattermost/blob/main/CONTRIBUTING.md#developer-workflow) followed
