### PR TITLE
chore: refactor to skip tests on arm64

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -46,12 +46,15 @@ jobs:
           registry1Password: ${{ secrets.IRON_BANK_ROBOT_PASSWORD }}
           ghToken: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        if: ${{ runner.arch == 'ARM64' }}
-        uses: docker/setup-qemu-action@v3
+      - name: Build Package
+        run: uds run -f tasks/publish.yaml build-package --set FLAVOR=${{ matrix.flavor }}
+
+      - name: Test Package
+        if: ${{ runner.arch != 'ARM64' }}
+        run: uds run -f tasks/publish.yaml test-package --set FLAVOR=${{ matrix.flavor }}
 
       - name: Publish Package
-        run: UDS_ARCHITECTURE=${{ matrix.architecture }} uds run -f tasks/publish.yaml package --set FLAVOR=${{ matrix.flavor }}
+        run: uds run -f tasks/publish.yaml publish-package --set FLAVOR=${{ matrix.flavor }}
 
       - name: Debug Output
         if: ${{ always() }}

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -7,11 +7,14 @@ includes:
   - setup: https://raw.githubusercontent.com/defenseunicorns/uds-common/v0.5.0/tasks/setup.yaml
 
 tasks:
-  - name: package
-    description: Build and publish the packages
-
+  - name: build-package
+    description: Build package
     actions:
       - task: create:package
+
+  - name: test-package
+    description: Test the package
+    actions:
       - task: dependencies:create
       - task: create:test-bundle
       - task: setup:k3d-test-cluster
@@ -19,6 +22,9 @@ tasks:
       - task: setup:create-doug-user
       - task: test:all
 
+  - name: publish-package
+    description: Publish the package
+    actions:
       - description: Publish the package
         task: publish:package
         with:


### PR DESCRIPTION
## Description

After doing some more experiments we decided to not run arm64 tests under emulation. We will still build the package but not run tests on it. This PR splits the publish steps up into build/test/publish so that they can be selectively ran based on architecture, skipping the tests on arm64.

## Related Issue

Relates to #84 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-mattermost/blob/main/CONTRIBUTING.md#developer-workflow) followed
