### PR TITLE
chore: exclude registry1 arm64 architecture from matrix

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -30,6 +30,9 @@ jobs:
       matrix:
         flavor: [upstream, registry1]
         architecture: [amd64, arm64]
+        exclude:
+          - flavor: registry1
+            architecture: arm64
     name: Publish ${{ matrix.flavor }} ${{ matrix.architecture }}
 
     permissions:


### PR DESCRIPTION
## Description
Exclude registry flavor + arm64 architecture combination from matrix. Missed this in original pre release testing changes.

## Related Issue

Relates to #84 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-mattermost/blob/main/CONTRIBUTING.md#developer-workflow) followed
