### PR TITLE
chore: add zarf annotations

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -9,6 +9,12 @@ metadata:
   # x-release-please-start-version
   version: "10.4.2-uds.0"
   # x-release-please-end
+  annotations:
+    title: Mattermost
+    description: Mattermost is a secure, open-source collaboration platform designed for teams who prioritize data control and privacy. This self-hosted messaging system offers a robust alternative to cloud-based chat services, allowing organizations to maintain full ownership of their communication data. Mattermost is ideal for organizations that require a reliable, secure, and customizable team communication solution without compromising on data sovereignty. It's particularly well-suited for development teams, security-conscious DoD teams, and missions looking to enhance internal collaboration while maintaining control over their infrastructure.
+    categories: Collaboration,Security,IT Management,Productivity
+    keywords: Secure Collaboration,Self-Hosted Messaging,Data Sovereignty,Team Communication,Customizable Platform,Privacy-Focused,Development Teams,DoD Teams,Internal Collaboration,Infrastructure Control
+    tagline: **Collaboration for Mission-Critical Work**
 
 variables:
   - name: SUBDOMAIN


### PR DESCRIPTION
Add Zarf annotations from security hub.

This PR adds metadata annotations from the security hub repository to the Zarf package configuration.

Changes:
- Add title annotation
- Add description annotation
- Add categories annotation
- Add keywords annotation
- Add tagline annotation (if present)
