### PR TITLE
feat: create service for calls plugin rtc server

### DIFF
--- a/chart/templates/mattermost-rtc-svc.yaml
+++ b/chart/templates/mattermost-rtc-svc.yaml
@@ -1,3 +1,5 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 {{- if .Values.rtcService.enabled }}
 apiVersion: v1

--- a/chart/templates/mattermost-rtc-svc.yaml
+++ b/chart/templates/mattermost-rtc-svc.yaml
@@ -1,0 +1,18 @@
+
+{{- if .Values.rtcService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: mattermost-rtc
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.rtcService }}
+  annotations:
+    {{- .annotations | toYaml | nindent 4 }}
+spec:
+  ports:
+    {{- .ports | toYaml | nindent 4 }}
+  selector:
+    app.kubernetes.io/name: mattermost-enterprise-edition
+  type: {{ .type }}
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -73,6 +73,20 @@ storage:
   namespace: minio
   port: 9000
 
+rtcService:
+  enabled: false
+  type: ClusterIP
+  annotations: {}
+  ports:
+    - name: udp-mattermost-rtc
+      port: 8443
+      protocol: UDP
+      targetPort: 8443
+    - name: tcp-mattermost-rtc
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+
 # additionalNetworkAllow:
 #    # Notice no `remoteGenerated` field here on custom internal rule
 #   - direction: Ingress

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,11 +36,6 @@ If you are using the [UDS Postgres Operator](https://github.com/defenseunicorns/
 - `postgres.host` - provides the host/domain name to use for the database (i.e. `pg-cluster.postgres.svc.cluster.local`)
 - `postgres.connectionOptions` - provides connection options to use when connecting to the database (i.e. `?connect_timeout=10`)
 
-- `rtcService.enabled` - enables rtc service for [calls plugin rtc server](https://docs.mattermost.com/configure/calls-deployment.html#network) (defaults to `false`)
-- `rtcService.type` - service type (defaults to `ClusterIP`)
-- `rtcService.annotations` - service annotations (defaults to `{}`)
-- `ports` - service port mappings, mattermost will default both udp and tcp to 8443 (defaults to `{"ports":[{"name":"udp-mattermost-rtc","port":8443,"protocol":"UDP","targetPort":8443},{"name":"tcp-mattermost-rtc","port":8443,"protocol":"TCP","targetPort":8443}]}`)
-
 ### IAM Roles for Service Accounts
 
 The Software Factory team has not yet tested IRSA with AWS RDS - there is an open issue linked below with further linked issues to test this that could act as a starting point to implement:
@@ -113,3 +108,41 @@ UDS bundle:
                     - name: mattermost-plugins
                       mountPath: /mattermost/plugins/
 ```
+
+### Calls Plugin
+The calls plugin [requires an externally-facing ingress for TCP and UDP traffic on port 8443](https://docs.mattermost.com/configure/calls-deployment.html#network). To assist with the creation of this ingress, the following parameters can be used:
+
+- `rtcService.enabled` - enables rtc service for [calls plugin rtc server](https://docs.mattermost.com/configure/calls-deployment.html#network) (defaults to `false`)
+- `rtcService.type` - service type (defaults to `ClusterIP`)
+- `rtcService.annotations` - service annotations (defaults to `{}`)
+- `rtcService.ports` - service port mappings, mattermost will default both udp and tcp to 8443 (defaults to `{"ports":[{"name":"udp-mattermost-rtc","port":8443,"protocol":"UDP","targetPort":8443},{"name":"tcp-mattermost-rtc","port":8443,"protocol":"TCP","targetPort":8443}]}`)
+
+For example, an internet facing load balancer on AWS that uses port 8443 for UDP and port 8444 for TCP:
+```yaml
+    overrides:
+      mattermost:
+        uds-mattermost-config:
+          values:
+            - path: rtcService
+              value:
+                enabled: true
+                type: LoadBalancer
+                annotations:
+                  service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
+                  service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+                  service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+                  service.beta.kubernetes.io/aws-load-balancer-type: external
+                  service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "32527"
+                  service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: tcp
+                ports:
+                  - name: udp-mattermost-rtc
+                    port: 8443
+                    protocol: UDP
+                    targetPort: 8443
+                  - name: tcp-mattermost-rtc
+                    port: 8444
+                    nodePort: 32527
+                    protocol: TCP
+                    targetPort: 8444
+```
+For the above example, there is an [EC2 Load Balancer limitation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html) where UDP health checks are not permitted. To overcome this, a healthcheck port and protocol override is provided as an annotation, configuring AWS to always use the TCP ingress as a healthcheck probe. The port number used in `service.beta.kubernetes.io/aws-load-balancer-healthcheck-port` and `nodePort` of `tcp-mattermost-rtc` must match for the healthcheck to be healthy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,11 @@ If you are using the [UDS Postgres Operator](https://github.com/defenseunicorns/
 - `postgres.host` - provides the host/domain name to use for the database (i.e. `pg-cluster.postgres.svc.cluster.local`)
 - `postgres.connectionOptions` - provides connection options to use when connecting to the database (i.e. `?connect_timeout=10`)
 
+- `rtcService.enabled` - enables rtc service for [calls plugin rtc server](https://docs.mattermost.com/configure/calls-deployment.html#network) (defaults to `false`)
+- `rtcService.type` - service type (defaults to `ClusterIP`)
+- `rtcService.annotations` - service annotations (defaults to `{}`)
+- `ports` - service port mappings, mattermost will default both udp and tcp to 8443 (defaults to `{"ports":[{"name":"udp-mattermost-rtc","port":8443,"protocol":"UDP","targetPort":8443},{"name":"tcp-mattermost-rtc","port":8443,"protocol":"TCP","targetPort":8443}]}`)
+
 ### IAM Roles for Service Accounts
 
 The Software Factory team has not yet tested IRSA with AWS RDS - there is an open issue linked below with further linked issues to test this that could act as a starting point to implement:


### PR DESCRIPTION
## Description
Allows for optional service to use for [calls plugin rtc server](https://docs.mattermost.com/configure/calls-deployment.html#network). For the calls plugin rtc server to work, port 8443 must be publicly accessible over both TCP and UDP.

Currently, Istio gateway only supports TCP so a separate load balancer is required for the UDP traffic. Since a separate load balancer is already required, this service will allow the user to expose both TCP and UDP on the same load balancer.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-mattermost/blob/main/CONTRIBUTING.md#developer-workflow) followed
