### PR TITLE
feat: update mattermost to use istio ambient mode

### DIFF
--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -12,7 +12,7 @@ metadata:
 packages:
   - name: minio-operator
     repository: ghcr.io/defenseunicorns/packages/uds/minio-operator
-    ref: 7.1.1-uds.0-upstream
+    ref: 7.1.1-uds.1-upstream
     overrides:
       minio-operator:
         uds-minio-config:
@@ -33,7 +33,7 @@ packages:
 
   - name: postgres-operator
     repository: ghcr.io/defenseunicorns/packages/uds/postgres-operator
-    ref: 1.14.0-uds.4-upstream
+    ref: 1.14.0-uds.6-upstream
     overrides:
       postgres-operator:
         uds-postgres-config:

--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -69,6 +69,8 @@ spec:
       description: Metrics
   {{- end }}
   network:
+    serviceMesh:
+      mode: ambient
     expose:
       - service: mattermost-enterprise-edition
         selector:


### PR DESCRIPTION
## Description

Updates mattermost to use Istio's ambient mode and updates the postgres and minio operator version dependencies to version that also use ambient. This update requires uds-core `v0.40.0` or later. 

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-mattermost/blob/main/CONTRIBUTING.md#developer-workflow) followed
