### PR TITLE
fix: reference zarf variable for licenses in an common values

### DIFF
--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -36,8 +36,8 @@ serviceAccount:
 
 global:
   siteUrl: "https://###ZARF_VAR_SUBDOMAIN###.###ZARF_VAR_DOMAIN###"
-  # Default unlicensed deployment
-  mattermostLicense: ""
+  # Default unlicensed deployment which is set to "" as a Zarf variable
+  mattermostLicense: "###ZARF_VAR_MM_LICENSE###"
 
   features:
     database:


### PR DESCRIPTION
## Description

Noticed that the `global.mattermostLicense` wasn't referencing the existing MM_LICENSE zarf variable. Fix it to be set by it.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-mattermost/blob/main/CONTRIBUTING.md#developer-workflow) followed
